### PR TITLE
Comment out consumerGroupMembers metric which is causing exporter instability

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,5 @@
 repository:
-    path: github.com/danielqsj/kafka_exporter
+    path: github.com/mr-yum/kafka_exporter
 build:
     flags: -a -tags netgo
     ldflags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  Daniel Qian <qsj.daniel@gmail.com>
 
 ARG TARGETARCH
-ARG BIN_DIR=.build/linux-${TARGETARCH}/
+ARG BIN_DIR=.build/linux-${TARGETARCH}
 
 COPY ${BIN_DIR}/kafka_exporter /bin/kafka_exporter
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
-DOCKER_IMAGE_NAME       ?= kafka-exporter
+DOCKER_IMAGE_NAME       ?= ghcr.io/mr-yum/kafka-exporter
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 TAG 					:= $(shell echo `if [ "$(TRAVIS_BRANCH)" = "master" ] || [ "$(TRAVIS_BRANCH)" = "" ] ; then echo "latest"; else echo $(TRAVIS_BRANCH) ; fi`)
 
@@ -45,13 +45,12 @@ tarball: promu
 
 docker: build
 	@echo ">> building docker image"
-	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" --build-arg BIN_DIR=. .
+	@docker build -t "$(DOCKER_IMAGE_NAME):latest" --build-arg BIN_DIR=. .
 
 push: crossbuild
-	@echo ">> building and pushing multi-arch docker images, $(DOCKER_USERNAME),$(DOCKER_IMAGE_NAME),$(TAG)"
-	@docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
+	@echo ">> building and pushing multi-arch docker images, mr-yum,$(DOCKER_IMAGE_NAME),latest"
 	@docker buildx create --use
-	@docker buildx build -t "$(DOCKER_USERNAME)/$(DOCKER_IMAGE_NAME):$(TAG)" \
+	@docker buildx build -t "$(DOCKER_IMAGE_NAME):latest" \
 		--output "$(PUSHTAG)" \
 		--platform "$(DOCKER_PLATFORMS)" \
 		.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/danielqsj/kafka_exporter
+module github.com/mr-yum/kafka_exporter
 
 go 1.17
 

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -54,7 +54,9 @@ var (
 	consumergroupLag                   *prometheus.Desc
 	consumergroupLagSum                *prometheus.Desc
 	consumergroupLagZookeeper          *prometheus.Desc
-	consumergroupMembers               *prometheus.Desc
+	// TODO(adrian.arumugam): Hack to patch kafka_exporter to make it reliable ASAP while
+	// a better upstream patch is figured out.
+	//consumergroupMembers               *prometheus.Desc
 )
 
 // Exporter collects Kafka stats from the given server and exports them using
@@ -573,9 +575,11 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 					}
 				}
 			}
-			ch <- prometheus.MustNewConstMetric(
-				consumergroupMembers, prometheus.GaugeValue, float64(len(group.Members)), group.GroupId,
-			)
+			// TODO(adrian.arumugam): Hack to patch kafka_exporter to make it reliable ASAP while
+			// a better upstream patch is figured out.
+			//ch <- prometheus.MustNewConstMetric(
+			//	consumergroupMembers, prometheus.GaugeValue, float64(len(group.Members)), group.GroupId,
+			//)
 			offsetFetchResponse, err := broker.FetchOffset(&offsetFetchRequest)
 			if err != nil {
 				glog.Errorf("Cannot get offset of group %s: %v", group.GroupId, err)
@@ -855,11 +859,13 @@ func setup(
 		[]string{"consumergroup", "topic"}, labels,
 	)
 
-	consumergroupMembers = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "consumergroup", "members"),
-		"Amount of members in a consumer group",
-		[]string{"consumergroup"}, labels,
-	)
+	// TODO(adrian.arumugam): Hack to patch kafka_exporter to make it reliable ASAP while
+	// a better upstream patch is figured out.
+	// consumergroupMembers = prometheus.NewDesc(
+	//	prometheus.BuildFQName(namespace, "consumergroup", "members"),
+	//	"Amount of members in a consumer group",
+	//	[]string{"consumergroup"}, labels,
+	// )
 
 	if logSarama {
 		sarama.Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)


### PR DESCRIPTION
Temporarily fork and patch `kafka_exporter` to avoid the use of `consumergroupMembers` metric which is causing intermittent metric export failures.

As this is temporary, I've done the bare minimum for quickly patching the issue and allowing us to build a docker image via `make docker` locally.

This has been tested locally: https://linear.app/mr-yum/issue/SRE-279#comment-09da3061

Multi-arch docker build as been executed and pushed to `mr-yum/kafka-exporter:latest` [1] for testing in staging. 

[1]: https://github.com/orgs/mr-yum/packages/container/package/kafka-exporter